### PR TITLE
Use the vendored version of coffeescript in the dev Procfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,3 @@
-message("@orta something changed in elan!") if files_modified.include? "/components/lib/variables/colors.json"
-message("@orta something changed in elan!") if files_modified.include? "/components/lib/variables/typography.json"
-message("@orta something changed in elan!") if files_modified.include? "/components/lib/variables/widths.json"
+if git.modified_files.include? "/components/lib/variables/*.json"
+  warn "There may need to be changes to the iOS frameworks."
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,46 @@
 GIT
   remote: https://github.com/danger/danger
-  revision: 9deecc680a579dfa2f1109b0228dd34a4d6664f7
+  revision: d19ce7cabd1e81f9e1219ee757098e81960c6f34
   specs:
-    danger (0.3.0)
-      claide
-      colored
-      faraday
-      octokit
-      redcarpet
-      rugged
-      terminal-table
+    danger (2.1.1)
+      claide (~> 1.0)
+      claide-plugins (> 0.9.0)
+      colored (~> 1.2)
+      cork (~> 0.1)
+      faraday (~> 0)
+      faraday-http-cache (~> 1.0)
+      git (~> 1)
+      kramdown (~> 1.5)
+      octokit (~> 4.2)
+      terminal-table (~> 1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.8)
-    claide (0.9.1)
+    addressable (2.4.0)
+    claide (1.0.0)
+    claide-plugins (0.9.1)
+      cork
+      nap
+      open4 (~> 1.3)
     colored (1.2)
+    cork (0.1.0)
+      colored (~> 1.2)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.0)
+      faraday (~> 0.8)
+    git (1.3.0)
+    kramdown (1.11.1)
     multipart-post (2.0.0)
-    octokit (4.2.0)
-      sawyer (~> 0.6.0, >= 0.5.3)
-    redcarpet (3.3.4)
-    rugged (0.23.3)
-    sawyer (0.6.0)
-      addressable (~> 2.3.5)
+    nap (1.1.0)
+    octokit (4.3.0)
+      sawyer (~> 0.7.0, >= 0.5.3)
+    open4 (1.3.4)
+    sawyer (0.7.0)
+      addressable (>= 2.3.5, < 2.5)
       faraday (~> 0.8, < 0.10)
-    terminal-table (1.5.2)
+    terminal-table (1.6.0)
 
 PLATFORMS
   ruby
@@ -36,4 +49,4 @@ DEPENDENCIES
   danger!
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: coffee index.coffee
+web: node_modules/.bin/coffee index.coffee
 assets: gulp build:development


### PR DESCRIPTION
Currently it relies on the globally installed coffeescript, which could be any version. Or, in my case, you could not have it installed globally.

I don't know the ramifications for doing that in production, so I only made it happen here.
